### PR TITLE
Add store to detect query changing

### DIFF
--- a/example/App.svelte
+++ b/example/App.svelte
@@ -33,6 +33,7 @@
     { path: '/posts/(?<postId>.*)', resolver: prefetchArticle },
     { path: '/admin', resolver: adminGuard },
     { path: '/login', resolver: _ => import("./Login.svelte") },
+    { path: '/query', resolver: _ => import("./Query.svelte") },
   ];
 </script>
 
@@ -41,6 +42,7 @@
     <li><a use:link href="/">Home</a></li>
     <li><a use:link href="/admin">Admin</a></li>
     <li><a use:link href="/login">Login</a></li>
+    <li><a use:link href="/query">Query</a></li>
   </ul>
 </div>
 

--- a/example/Query.svelte
+++ b/example/Query.svelte
@@ -1,0 +1,14 @@
+<script>
+  import { link } from "../src/link.js";
+  import { currentURL } from "../src/stores.js";
+
+  $: name = $currentURL.searchParams.get("name") || 'unknown';
+</script>
+<svelte:head>
+  <title>query</title>
+</svelte:head>
+<div class="query">
+  <p>name: <span id="name">{ name }</span></p>
+  <a use:link href="/query?name=foo">foo</a>
+  <a use:link href="/query?name=bar">bar</a>
+</div>

--- a/server.js
+++ b/server.js
@@ -15,6 +15,8 @@ const STATIC_FILES = [
   "Article.js.map",
   "Login.js",
   "Login.js.map",
+  "Query.js",
+  "Query.js.map",
   "index.html",
   "main.js",
   "main.js.map",

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from 'svelte';
 
-  import { currentPath, currentRoute } from './stores.js';
+  import { currentPath, currentRoute, currentURL } from './stores.js';
   import { push } from './push.js';
 
   // @type{Array.{path: string, component: SvelteComponent}}
@@ -14,6 +14,7 @@
   onMount(() => {
     const onPopState = (evt) => {
       currentPath.set(window.location.pathname);
+      currentURL.setCurrent();
     };
 
     window.addEventListener('popstate', onPopState);

--- a/src/push.js
+++ b/src/push.js
@@ -1,4 +1,4 @@
-import { currentPath } from "./stores.js";
+import { currentPath, currentURL } from "./stores.js";
 
 export function push(next) {
   window.history.pushState({}, "", next);
@@ -6,4 +6,5 @@ export function push(next) {
   // Exclude queryString and hash
   const url = new URL(next, window.location.origin);
   currentPath.set(url.pathname);
+  currentURL.set(url);
 }

--- a/src/stores.js
+++ b/src/stores.js
@@ -10,3 +10,21 @@ export const currentRoute = writable(null);
 export const routeParams = derived(currentRoute, ($currentRoute) => {
   return $currentRoute ? $currentRoute.params || {} : {};
 });
+
+// Store of current location (to detect changes of query or hash)
+export const currentURL = (() => {
+  function getCurrent() {
+    return new URL(window.location);
+  }
+  const { subscribe, set } = writable(getCurrent());
+
+  return {
+    subscribe,
+    set(url) {
+      set(url);
+    },
+    setCurrent() {
+      set(getCurrent());
+    }
+  }
+})();

--- a/tests/test_e2e.js
+++ b/tests/test_e2e.js
@@ -103,3 +103,26 @@ export async function testGuard() {
     ok((await page.url()).includes('/admin'));
   });
 }
+
+export async function testQuery() {
+  await browserFixture(async (browser, page, serverUrl) => {
+    await page.goto(serverUrl);
+    await page.waitForSelector("div.home");
+
+    await page.click('a[href="/query"]');
+    await page.waitForSelector("div.query");
+    let name = await page.$eval('#name', e => e.innerText);
+    is(name, "unknown");
+
+    await page.click('a[href="/query?name=foo"]');
+    name = await page.$eval('#name', e => e.innerText);
+    is(name, "foo");
+
+    // Back
+    await page.goBack();
+    await page.waitFor(30);
+    name = await page.$eval('#name', e => e.innerText);
+    is(name, "unknown");
+
+  });
+}


### PR DESCRIPTION
This will add a store to detect changes that the URL (including query string or hash) has been modified.

Routing depends on path (location.pathname) as same as before.

# Example

```html
<script>
  import { currentURL } from "svelte-spa-history-router";

  $: name = $currentURL.searchParams.get("name") || 'unknown';
</script>
<div>{ name }</div>
```

# Note

Assumed use case likes giving initial selected value to search (filter) form from a link. but it may be a better solution to use `store` (in trial)
