### PR TITLE
Add the way to get routing params to via props

### DIFF
--- a/examples/app-svelte5/src/App.svelte
+++ b/examples/app-svelte5/src/App.svelte
@@ -3,6 +3,7 @@
   import { Router, push, link, redirect } from "svelte-spa-history-router";
 
   import Home from "./pages/Home.svelte";
+  import Guide from "./pages/Guide.svelte";
   import NotFound from "./pages/NotFound.svelte";
 
   import { getArticle } from "./articles.js";
@@ -30,6 +31,10 @@
       resolver: prefetchArticle,
     },
     {
+      path: "/guide/(?<guideId>\\d+)",
+      component: Guide,
+    },
+    {
       path: "/admin",
       resolver: () => {
         if (user === "anonymous") {
@@ -47,6 +52,7 @@
     <nav>
       <a use:link href="/">home</a> |
       <a use:link href="/blog">blog</a> |
+      <a use:link href="/guide/1">guide(1)</a> |
       <a use:link href="/admin">admin</a> |
       user: { user }
       {#if user === "anonymous"}

--- a/examples/app-svelte5/src/pages/Guide.svelte
+++ b/examples/app-svelte5/src/pages/Guide.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { RouteParams } from "svelte-spa-history-router";
+  import { routeParams, link } from "svelte-spa-history-router";
+
+  let { params }: { params: RouteParams } = $props();
+
+  const guideId = $derived(parseInt(params.guideId));
+</script>
+<svelte:head>
+  <title>Guide { guideId }</title>
+</svelte:head>
+<main class="guide">
+  <h1>Guide { guideId }</h1>
+  <p class="routeParams">routeParams: { $routeParams.guideId }</p>
+  <p class="params">params: { params.guideId }</p>
+  <ul>
+    {#each [1, 2, 3] as idx }
+      <li><a use:link href={`/guide/${idx}`}>guide({idx})</a></li>
+    {/each}
+  </ul>
+</main>

--- a/examples/app-svelte5/tests/e2e.spec.js
+++ b/examples/app-svelte5/tests/e2e.spec.js
@@ -55,3 +55,15 @@ test("browser back", async ({ page }) => {
   await expect(page).toHaveTitle("Home");
   await expect(page).toHaveURL("/");
 });
+
+test.describe("route params", () => {
+  for (const id of [1, 2]) {
+    test(`with id=${id}`, async({ page }) => {
+      await page.goto(`/guide/${id}`);
+      await page.waitForSelector("main.guide");
+      await expect(page).toHaveTitle(`Guide ${id}`);
+      expect(await page.innerText(".routeParams")).toBe(`routeParams: ${id}`);
+      expect(await page.innerText(".params")).toBe(`params: ${id}`);
+    });
+  }
+});

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -96,6 +96,10 @@
     }
     if (!component) throw new Error("Component is not specified");
 
+    if (Object.keys(params).length !== 0) {
+      props.params = params;
+    }
+
     return /** @type {RouteState} */({ params, component, props });
   }
 

--- a/src/stores.js
+++ b/src/stores.js
@@ -33,6 +33,8 @@ export const routeState = writable(null);
 /**
  * Store of captured variables in path
  *
+ * scheduled to be deprecated after svelte5 released
+ *
  * @type Readable<RouteParams>
  */
 export const routeParams = derived(routeState, ($routeState) => {


### PR DESCRIPTION
In svelte5, the error like `<MyComponent> was created with unknown prop 'xxx'` when passing a dynamic property with `<svelte:component>` will be resolved. In addition, store is deprecated from svelte 5 .
Therefore, we are considering changing to assign route params to a component property called params instead of using store, and changing routeParams store to deprecated.

example

```html
<!-- App.svelte -->
<script lang="ts">
  import Router from "svelte-spa-history-router";

  const routes = [
    { path: "/item/(?<id>.+)", component: MyComponent }
  ];
</script>
<Route {routes}/>


<!-- MyComponent.svelte -->
<script lang="ts">
  import type { RouteParams } from "svelte-spa-history-router";

  let { params }: { params: RouteParams } = $props();
</script>
<div>{ params.id }</div>
```

svelte 5 is still in the rc stage, so we'll wait and see how it goes to merge to main.