### PR TITLE
Fix component type on svelte5

### DIFF
--- a/examples/app-svelte5/package-lock.json
+++ b/examples/app-svelte5/package-lock.json
@@ -13,17 +13,21 @@
         "@sveltejs/vite-plugin-svelte": "^3.1.0",
         "@types/node": "^20.12.12",
         "playwright": "^1.44.0",
-        "svelte": "^5.0.0-next.136",
+        "svelte": "^5.0.0-next.144",
         "svelte-spa-history-router": "file:../..",
         "vite": "^5.2.11"
       }
     },
     "../..": {
-      "version": "2.1.2",
+      "version": "2.2.0-next.0",
       "dev": true,
       "license": "MIT",
       "devDependencies": {
-        "prettier": "3.2.1"
+        "prettier": "3.2.1",
+        "svelte": "4.2.17"
+      },
+      "peerDependencies": {
+        "svelte": "*"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1066,10 +1070,11 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.0.0-next.136",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.0.0-next.136.tgz",
-      "integrity": "sha512-M3jHAIfWZ7K+hjZdvu2p53ZtWE843yubxJfjxeQw9XiwMYG5z6quCA5u8r23GrxAp20JBl36B6ucbZvLUf0Z/g==",
+      "version": "5.0.0-next.144",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.0.0-next.144.tgz",
+      "integrity": "sha512-akjtRBHzaLa1XdMv9tBGkXE5N2JaRc3gL+ZIctjc9Gew9DF7NxGTlxXq+HR9yUV7Lsg4o9ltMfkxz8H3K7piNQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",

--- a/examples/app-svelte5/package.json
+++ b/examples/app-svelte5/package.json
@@ -15,7 +15,7 @@
     "@sveltejs/vite-plugin-svelte": "^3.1.0",
     "@types/node": "^20.12.12",
     "playwright": "^1.44.0",
-    "svelte": "^5.0.0-next.136",
+    "svelte": "^5.0.0-next.144",
     "svelte-spa-history-router": "file:../..",
     "vite": "^5.2.11"
   },

--- a/examples/app-svelte5/src/App.svelte
+++ b/examples/app-svelte5/src/App.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-  import type { ResolverArgs } from "svelte-spa-history-router";
+  import type { Component } from "svelte";
+
+  import type { Route, AsyncResolver } from "svelte-spa-history-router";
   import { Router, push, link, redirect } from "svelte-spa-history-router";
 
   import Home from "./pages/Home.svelte";
@@ -10,11 +12,8 @@
 
   let user = $state("anonymous");
 
-  /**
-   * FIXME: better to Use AsyncResolver type, but ComponentType cause error on currently svelte build
-   */
-  async function prefetchArticle({ params, props }: ResolverArgs) {
-    const article = await getArticle(params.postId);
+  const prefetchArticle: AsyncResolver<Component<any, any, any>> = async ({ params, props }) => {
+    const article = await getArticle(params.postId ?? "");
     if (article) {
       props.article = article;
       return import("./pages/Post.svelte");
@@ -23,7 +22,7 @@
     }
   }
 
-  const routes = [
+  const routes: Route<Component<any, any, any>>[] = [
     { path: "/", component: Home },
     { path: "/blog", resolver: () => import("./pages/Blog.svelte") },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -118,6 +119,7 @@
       "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
       "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@types/estree": "^1.0.1",
@@ -131,6 +133,7 @@
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
       "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mdn-data": "2.0.30",
         "source-map-js": "^1.0.1"
@@ -153,6 +156,7 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -185,13 +189,15 @@
       "version": "2.0.30",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-      "dev": true
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/periscopic": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
       "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^3.0.0",
@@ -218,6 +224,7 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
       "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -227,6 +234,7 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.17.tgz",
       "integrity": "sha512-N7m1YnoXtRf5wya5Gyx3TWuTddI4nAyayyIWFojiWV5IayDYNV5i2mRp/7qNGol4DtxEYxljmrbgp1HM6hUbmQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -1,7 +1,5 @@
 <script>
   /**
-   * @typedef { import("svelte").ComponentType } ComponentType
-   *
    * @typedef { import("./types").ComponentModule } ComponentModule
    * @typedef { import("./types").Route } Route
    * @typedef { import("./types").Redirection } Redirection
@@ -91,7 +89,7 @@
       if (Reflect.has(resolved, "default")) {
         component = /** @type {ComponentModule} */(resolved).default;
       } else {
-        component = /** @type {ComponentType} */(resolved);
+        component = /** @type {ComponentModule["default"]} */(resolved);
       }
     }
     if (!component) throw new Error("Component is not specified");

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,8 @@ export type RouteProps = {
   [key: string]: any
 }
 
-export type ComponentModule = {
-  default: ComponentType,
+export type ComponentModule<T = ComponentType> = {
+  default: T,
 }
 
 export type Redirection = {
@@ -23,8 +23,8 @@ export interface CurrentURL extends Readable<URL> {
   setCurrent: () => void
 }
 
-export type RouteState = {
-  component: ComponentType,
+export type RouteState<T = ComponentType> = {
+  component: T,
   params: RouteParams,
   props: RouteProps,
 }
@@ -35,16 +35,16 @@ export type ResolverArgs = {
   props: RouteProps,
 }
 
-export type SyncResolver = (
+export type SyncResolver<T = ComponentType> = (
   args: ResolverArgs
-) => ComponentType | Redirection
+) => T | Redirection
 
-export type AsyncResolver = (
+export type AsyncResolver<T = ComponentType> = (
   args: ResolverArgs
-) => Promise<ComponentType | ComponentModule | Redirection>
+) => Promise<T | ComponentModule<T> | Redirection>
 
-export type Route = {
+export type Route<T = ComponentType> = {
   path: string,
-  component?: ComponentType,
-  resolver?: SyncResolver | AsyncResolver,
+  component?: T,
+  resolver?: SyncResolver<T> | AsyncResolver<T>,
 }


### PR DESCRIPTION
New Component type was added on [svelte@5.0.0-next.143](https://github.com/sveltejs/svelte/releases/tag/svelte%405.0.0-next.143)

Since `ComponentType` (\~svelte4) and `Component` (svelte5\~) are incompatible, we used generics to allow the user to choose which one to use. 

See examples/app-svelte5 for usage.
